### PR TITLE
Optimization of the Fréchet decider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For now, only the details interfaces are available. You need to specify explicit
 following line from sample/bg.cpp
 ```
     frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      point_type, // the point type
+      linestring_type, // the trajectory type
       std::function<double(point_type, point_type)>, // the squared distance signature
       std::function<double(point_type)>, // the X getter signature
       std::function<double(point_type)> > // the Y getter signature
@@ -54,7 +54,7 @@ following line from sample/bg.cpp
       );
 
 ```
-As you can see, the type point_type is being used and we give lambda-expressions for the three needed functionals squared_distance (comparable_distance
+As you can see, the type linestring_type is being used and we give lambda-expressions for the three needed functionals squared_distance (comparable_distance
 in boost::geometry is some fast implementation of a distance such that compare is correct. It is the squared distance for Euclidean geometries, but might
 be something different for other geometries. Additionally, we forward the boost::geometry getter for X and Y as the second and third constructor
 parameters.
@@ -80,3 +80,5 @@ After constructing this object, it can be used quite cleanly, for example as in
 # Contributors
 Martin Werner - boilerplate, R-package, some integration work
 More to come.
+
+Fabian Dütsch - optimization of the Fréchet decider

--- a/samples/bg.cpp
+++ b/samples/bg.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 
     // instantiate some decider, this time fully specified.
     frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      point_type, // the point type
+      linestring_type, // the trajectory type
       std::function<double(point_type, point_type)>, // the squared distance signature
       std::function<double(point_type)>, // the X getter signature
       std::function<double(point_type)> > // the Y getter signature

--- a/samples/plain.cpp
+++ b/samples/plain.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   trajectory t2 = {{1, 1}, {2, 2}, {1, 3}};
 
   frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      point, distance_functional_type, std::function<double(point p)>,
+      trajectory, distance_functional_type, std::function<double(point p)>,
       std::function<double(point p)>>
       fd(squared_dist, getx, gety);
 


### PR DESCRIPTION
-Improved the Fréchet decider by only computing the circle-line-intersection for free-space segments that are not entirely reachable
-Generalized the Fréchet decider by introducing a template parameter for the trajectory type that only requires the methods operator[] and size