### PR TITLE
Grid structure for range queries and minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ For now, only the details interfaces are available. You need to specify explicit
 following line from sample/bg.cpp
 ```
     frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      linestring_type, // the trajectory type
       std::function<double(point_type, point_type)>, // the squared distance signature
       std::function<double(point_type)>, // the X getter signature
       std::function<double(point_type)> > // the Y getter signature
@@ -54,10 +53,9 @@ following line from sample/bg.cpp
       );
 
 ```
-As you can see, the type linestring_type is being used and we give lambda-expressions for the three needed functionals squared_distance (comparable_distance
-in boost::geometry is some fast implementation of a distance such that compare is correct. It is the squared distance for Euclidean geometries, but might
-be something different for other geometries. Additionally, we forward the boost::geometry getter for X and Y as the second and third constructor
-parameters.
+As you can see, we give lambda-expressions for the three needed functionals squared_distance (comparable_distance in boost::geometry is some
+fast implementation of a distance such that compare is correct). It is the squared distance for Euclidean geometries, but might be something
+different for other geometries. Additionally, we forward the boost::geometry getter for X and Y as the second and third constructor parameters.
 
 After constructing this object, it can be used quite cleanly, for example as in
 ```
@@ -81,4 +79,4 @@ After constructing this object, it can be used quite cleanly, for example as in
 Martin Werner - boilerplate, R-package, some integration work
 More to come.
 
-Fabian Dütsch - optimization of the Fréchet decider
+Fabian Dütsch - Grid, optimization of the Fréchet decider

--- a/include/frechetrange.hpp
+++ b/include/frechetrange.hpp
@@ -50,8 +50,8 @@ namespace duetschvahrenhold {
 */
 static constexpr double BEGIN_NOT_REACHABLE = 2.0;
 
-template <typename Trajectory, typename squareddistancefunctional,
-          typename xgetterfunctional, typename ygetterfunctional>
+template <typename squareddistancefunctional, typename xgetterfunctional,
+          typename ygetterfunctional>
 class FrechetDistance {
 public:
   FrechetDistance(squareddistancefunctional squaredDistance,
@@ -67,6 +67,7 @@ public:
   * by the passed upper bound.
   * @pre Neither of the trajectories is empty.
   */
+  template <typename Trajectory>
   bool isBoundedBy(const Trajectory &traj1, const Trajectory &traj2,
                    const double distanceBound) {
     const double boundSquared = distanceBound * distanceBound;
@@ -116,7 +117,7 @@ private:
   * Decides the Fréchet distance problem for a trajectory consisting of only
   * one point.
   */
-  template <typename point_type>
+  template <typename Trajectory, typename point_type>
   bool comparePointToTrajectory(const point_type &p,
                                 const Trajectory &trajectory,
                                 const double boundSquared) {
@@ -135,6 +136,7 @@ private:
   * such that each matching is within the passed distance bound and the
   * sequence of segment points is monotone.
   */
+  template <typename Trajectory>
   bool matchInnerPointsMonotonously(const Trajectory &points,
                                     const Trajectory &segments,
                                     double boundSquared) const {
@@ -190,6 +192,7 @@ private:
   * @pre Both trajectories consist of at least two points
   *      and the starting and ending points are within distance.
   */
+  template <typename Trajectory>
   bool traverseFreeSpaceDiagram(const Trajectory &p1, const Trajectory &p2,
                                 const double boundSquared) {
     // init the beginnings of reachable parts of the "frontline",
@@ -759,8 +762,8 @@ private:
   */
   bool _optimized;
 
-  mutable FrechetDistance<Trajectory, squareddistancefunctional,
-                          xgetterfunctional, ygetterfunctional>
+  mutable FrechetDistance<squareddistancefunctional, xgetterfunctional,
+                          ygetterfunctional>
       _decider;
   squareddistancefunctional _squaredDistance;
   xgetterfunctional _getX;
@@ -1042,9 +1045,9 @@ private:
       // if it is within Fréchet distance of the query trajectory
       if (squaredfarthestBBDistance(queryMBR, trajMBR) <=
               threshold * threshold ||
-          _decider.isBoundedBy(queryMBR.trajectory, trajMBR.trajectory,
-                               threshold)) {
-        output.push_back(&(trajMBR.trajectory));
+          _decider.template isBoundedBy<Trajectory>(
+              queryMBR.trajectory, trajMBR.trajectory, threshold)) {
+        output(&(trajMBR.trajectory));
       }
     }
   }

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,3 +1,4 @@
 all:
-	g++ -o plain plain.cpp -Wall -std=c++11 
+	g++ -o plain plain.cpp -Wall -std=c++11
 	g++ -o bg bg.cpp -Wall -std=c++11
+	g++ -o grid grid.cpp -Wall -std=c++11

--- a/samples/bg.cpp
+++ b/samples/bg.cpp
@@ -41,7 +41,6 @@ int main(int argc, char **argv) {
 
     // instantiate some decider, this time fully specified.
     frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      linestring_type, // the trajectory type
       std::function<double(point_type, point_type)>, // the squared distance signature
       std::function<double(point_type)>, // the X getter signature
       std::function<double(point_type)> > // the Y getter signature

--- a/samples/grid.cpp
+++ b/samples/grid.cpp
@@ -38,10 +38,9 @@ int main(int argc, char **argv) {
   grid.reserve(2); // not mandatory, but adviced in case of many inserts
   grid.insert(t1);
   grid.insert(t2);
-  grid.optimize(); // not mandatory, but adviced after completing all/most
-                   // inserts
+  grid.optimize(); // not mandatory, but adviced after completing all/most inserts
 
-  // first overload of rangeQuery: returning the result set
+  // first version of rangeQuery: returning the result set
   auto results = grid.rangeQuery(q1, distThreshold1);
 
   cout << "Data trajectories within Frechet distance " << distThreshold1
@@ -52,7 +51,7 @@ int main(int argc, char **argv) {
     cout << endl;
   }
 
-  // second overload of rangeQuery: using an output funcional
+  // second version of rangeQuery: using an output functional
   cout << endl;
   cout << "Data trajectories within Frechet distance " << distThreshold2
        << " of q2:" << endl;

--- a/samples/grid.cpp
+++ b/samples/grid.cpp
@@ -1,0 +1,50 @@
+/*
+This sample illustrates how to use the grid data structure from a
+minimalistic, dependency-free C++ / STL project.
+*/
+#include <functional>
+#include <iostream>
+
+#include "../include/frechetrange.hpp"
+
+using std::cout;
+using std::endl;
+
+typedef std::vector<double> point;
+typedef std::function<double(point, point)> distance_functional_type;
+typedef std::vector<point> trajectory;
+
+distance_functional_type squared_dist = [](point p1, point p2) {
+  // provide a squared distance functional for the point type
+  return (p2[0] - p1[0]) * (p2[0] - p1[0]) + (p2[1] - p1[1]) * (p2[1] - p1[1]);
+};
+std::function<double(point p)> getx = [](point p) { return p[0]; };
+std::function<double(point p)> gety = [](point p) { return p[1]; };
+
+int main(int argc, char **argv) {
+  trajectory t1 = {{0, 0}, {0, 1}, {0, 2}};
+  trajectory t2 = {{2, 2}, {4, 3}, {0, 3}};
+  trajectory q = {{1, 1}, {2, 2}, {1, 3}};
+  const double distThreshold = 2.0;
+
+  frechetrange::detail::duetschvahrenhold::Grid<
+      trajectory, distance_functional_type, std::function<double(point p)>,
+      std::function<double(point p)>>
+      grid(distThreshold, squared_dist, getx, gety);
+
+  grid.reserve(2); // not mandatory, but adviced in case of many inserts
+  grid.insert(t1);
+  grid.insert(t2);
+  grid.optimize();
+
+  auto results = grid.rangeQuery(q, distThreshold);
+  cout << "Data trajectories within Frechet distance " << distThreshold << ":"
+       << endl;
+  for (const trajectory *t : results) {
+    for (const auto &p : *t)
+      cout << "( " << p[0] << ", " << p[1] << " ); ";
+    cout << endl;
+  }
+
+  return 0;
+}

--- a/samples/grid.cpp
+++ b/samples/grid.cpp
@@ -24,27 +24,44 @@ std::function<double(point p)> gety = [](point p) { return p[1]; };
 int main(int argc, char **argv) {
   trajectory t1 = {{0, 0}, {0, 1}, {0, 2}};
   trajectory t2 = {{2, 2}, {4, 3}, {0, 3}};
-  trajectory q = {{1, 1}, {2, 2}, {1, 3}};
-  const double distThreshold = 2.0;
+  trajectory q1 = {{1.5, 1.5}, {3, 2.5}, {3.5, 3.5}, {0, 2}};
+  const double distThreshold1 = 1.5;
+  trajectory q2 = {{1, 1}, {2, 2}, {1, 3}};
+  const double distThreshold2 = 2.0;
 
+  double meshSize = std::max(distThreshold1, distThreshold2);
   frechetrange::detail::duetschvahrenhold::Grid<
       trajectory, distance_functional_type, std::function<double(point p)>,
       std::function<double(point p)>>
-      grid(distThreshold, squared_dist, getx, gety);
+      grid(meshSize, squared_dist, getx, gety);
 
   grid.reserve(2); // not mandatory, but adviced in case of many inserts
   grid.insert(t1);
   grid.insert(t2);
-  grid.optimize();
+  grid.optimize(); // not mandatory, but adviced after completing all/most
+                   // inserts
 
-  auto results = grid.rangeQuery(q, distThreshold);
-  cout << "Data trajectories within Frechet distance " << distThreshold << ":"
-       << endl;
+  // first overload of rangeQuery: returning the result set
+  auto results = grid.rangeQuery(q1, distThreshold1);
+
+  cout << "Data trajectories within Frechet distance " << distThreshold1
+       << " of q1:" << endl;
   for (const trajectory *t : results) {
-    for (const auto &p : *t)
+    for (const point &p : *t)
       cout << "( " << p[0] << ", " << p[1] << " ); ";
     cout << endl;
   }
+
+  // second overload of rangeQuery: using an output funcional
+  cout << endl;
+  cout << "Data trajectories within Frechet distance " << distThreshold2
+       << " of q2:" << endl;
+  auto output = [](const trajectory *t) {
+    for (const point &p : *t)
+      cout << "( " << p[0] << ", " << p[1] << " ); ";
+    cout << endl;
+  };
+  grid.rangeQuery(q2, distThreshold2, output);
 
   return 0;
 }

--- a/samples/plain.cpp
+++ b/samples/plain.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   trajectory t2 = {{1, 1}, {2, 2}, {1, 3}};
 
   frechetrange::detail::duetschvahrenhold::FrechetDistance<
-      trajectory, distance_functional_type, std::function<double(point p)>,
+      distance_functional_type, std::function<double(point p)>,
       std::function<double(point p)>>
       fd(squared_dist, getx, gety);
 


### PR DESCRIPTION
* Integrated the Grid structure from Dütsch and Vahrenhold for range queries
  with the preliminary public interface:
```
    template <typename Trajectory, typename squareddistancefunctional,
              typename xgetterfunctional, typename ygetterfunctional>
    class Grid {
      Grid(double meshSize, squareddistancefunctional,
           xgetterfunctional, ygetterfunctional);
      Grid(const Grid &);
      Grid(Grid &&);
      Grid &operator=(const Grid &);
      Grid &operator=(Grid &&);
      double getMeshSize() const;

      void reserve(size_t numTrajectories);
      void insert(const Trajectory &);
      void insert(Trajectory &&);
      void optimize();

      std::vector<const Trajectory *> rangeQuery(const Trajectory &query,
                                                 double distanceThreshold);
      template <typename OutputFunctional>
      void rangeQuery(const Trajectory &query, double distanceThreshold,
                      OutputFunctional &output);
    };
```
* Minor changes to class FrechetDistance, especially moved template parameter trajectory
  to method isBoundedBy, such that it can be deduced automatically and a single object
  can be used for different trajectory type instantiations.